### PR TITLE
optimize images, lazy loading, portfolio

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,18 @@
-import React, { useState, useEffect } from "react";
+import React, { Suspense, lazy, useEffect, useState } from "react";
 import { BrowserRouter as Router, Routes, Route, useNavigate, useLocation } from "react-router-dom";
 import Portfolio from "./pages/Portfolio";
-import About from "./pages/About";
-import Resume from "./pages/Resume";
-import WorkDetail from "./pages/WorkDetail";
 import NotFound from "./pages/NotFound";
-import './index.css';
+import "./index.css";
 import NavigationBar from "./components/NavigationBar";
 import Footer from "./components/Footer";
 import ScrollToTop from "./components/ScrollToTop";
-import CaseStudies from "./pages/CaseStudies";
+
+const About = lazy(() => import("./pages/About"));
+const Resume = lazy(() => import("./pages/Resume"));
+const WorkDetail = lazy(() => import("./pages/WorkDetail"));
+const CaseStudies = lazy(() => import("./pages/CaseStudies"));
+
+const RouteFallback = () => <div className="min-h-[40vh]" aria-hidden="true" />;
 
 function AppContent() {
   const navigate = useNavigate();
@@ -39,19 +42,21 @@ function AppContent() {
     <div className="min-h-screen w-full overflow-x-hidden flex flex-col">
       <NavigationBar currentPage={currentPath} onNavigate={handleNavigate} />
       <main className="flex-grow">
-        <div className={`transition-opacity duration-300 ease-in-out ${fadeClass}`}>
-          <Routes>
-            <Route path="/" element={<Portfolio onNavigate={handleNavigate} />} />
-            <Route path="/portfolio" element={<Portfolio onNavigate={handleNavigate} />} />
-            <Route path="/about" element={<About />} />
-            <Route path="/resume" element={<Resume />} />
-            <Route path="/projects/:projectName/:caseName" element={<WorkDetail />} />
-            <Route path="/projects/:projectName" element={<WorkDetail />} />
-            <Route path="/case-studies" element={<CaseStudies onNavigate={handleNavigate}/>} />
-            <Route path="/case-studies/:projectName" element={<WorkDetail />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </div>
+        <Suspense fallback={<RouteFallback />}>
+          <div className={`transition-opacity duration-300 ease-in-out ${fadeClass}`}>
+            <Routes>
+              <Route path="/" element={<Portfolio onNavigate={handleNavigate} />} />
+              <Route path="/portfolio" element={<Portfolio onNavigate={handleNavigate} />} />
+              <Route path="/about" element={<About />} />
+              <Route path="/resume" element={<Resume />} />
+              <Route path="/projects/:projectName/:caseName" element={<WorkDetail />} />
+              <Route path="/projects/:projectName" element={<WorkDetail />} />
+              <Route path="/case-studies" element={<CaseStudies onNavigate={handleNavigate} />} />
+              <Route path="/case-studies/:projectName" element={<WorkDetail />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </div>
+        </Suspense>
       </main>
       <Footer />
     </div>

--- a/src/components/WorkShowcase.tsx
+++ b/src/components/WorkShowcase.tsx
@@ -35,6 +35,8 @@ const WorkShowcase: React.FC<WorkShowcaseProps> = ({
               className="rounded-2xl transition-transform duration-300 ease-in-out hover:scale-105 max-w-full h-auto object-contain"
               src={image}
               alt={title}
+              loading="lazy"
+              decoding="async"
             />
           </div>
           <div className="flex flex-col justify-end p-10 pt-0 sm:p-16">

--- a/src/components/projectSections/ClickableImage.tsx
+++ b/src/components/projectSections/ClickableImage.tsx
@@ -17,6 +17,8 @@ const ClickableImage = ({
                     src={image}
                     alt={header}
                     className="w-full transition duration-300 ease-in-out"
+                    loading="lazy"
+                    decoding="async"
                 />
                 <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition duration-300 rounded" />
                 </a>

--- a/src/components/projectSections/ComplexGridImageSection.tsx
+++ b/src/components/projectSections/ComplexGridImageSection.tsx
@@ -30,9 +30,11 @@ const ComplexGridImageSection = ({
                     {images.map((image, idx) => (
                         <div key={idx} className="w-full py-1">
                             <img
-                            src={image}
-                            alt={`${header} logo ${idx + 1}`}
-                            className="mx-auto"
+                                src={image}
+                                alt={`${header} logo ${idx + 1}`}
+                                className="mx-auto"
+                                loading="lazy"
+                                decoding="async"
                             />
                         </div>
                     ))}

--- a/src/components/projectSections/ImageSlideSection.tsx
+++ b/src/components/projectSections/ImageSlideSection.tsx
@@ -26,6 +26,8 @@ const ImageSlideSection = ({
                         src={image}
                         alt={header}
                         className="py-6 md:py-10 h-auto max-w-full"
+                        loading="lazy"
+                        decoding="async"
                     />
                 )}
             </div>

--- a/src/components/projectSections/MultipleImageFullSection.tsx
+++ b/src/components/projectSections/MultipleImageFullSection.tsx
@@ -16,7 +16,12 @@ const MultipleImageFullSection = ({ category, header, description, images, bulle
             <div className="max-w-5xl mx-auto flex flex-col items-left py-16 px-10 lg:px-0">
                 {images.map((image, idx) => (
                     <div key={idx} className="w-full py-5">
-                        <img src={image} alt={`${header} logo ${idx + 1}`} />
+                        <img
+                            src={image}
+                            alt={`${header} logo ${idx + 1}`}
+                            loading="lazy"
+                            decoding="async"
+                        />
                     </div>
                 ))}
 

--- a/src/components/projectSections/SimpleImageSection.tsx
+++ b/src/components/projectSections/SimpleImageSection.tsx
@@ -26,9 +26,11 @@ const SimpleImageSection = ({
                 {images.map((image, idx) => (
                     <div key={idx} className="w-full py-1">
                         <img
-                        src={image}
-                        alt={`${header} logo ${idx + 1}`}
-                        className="mx-auto"
+                            src={image}
+                            alt={`${header} logo ${idx + 1}`}
+                            className="mx-auto"
+                            loading="lazy"
+                            decoding="async"
                         />
                     </div>
                 ))}

--- a/src/components/projectSections/SimpleLeftTextSection.tsx
+++ b/src/components/projectSections/SimpleLeftTextSection.tsx
@@ -29,6 +29,8 @@ const SimpleLeftTextSection = ({ header, paragraphs, image, textColor, bgColor }
                             src={image}
                             alt={header}
                             className="w-full"
+                            loading="lazy"
+                            decoding="async"
                         />
                     </div>
                 </div>

--- a/src/components/projectSections/SimpleRightTextSection.tsx
+++ b/src/components/projectSections/SimpleRightTextSection.tsx
@@ -18,6 +18,8 @@ const SimpleRightTextSection = ({ header, paragraphs, image, textColor, bgColor 
                             src={image}
                             alt={header}
                             className="w-full"
+                            loading="lazy"
+                            decoding="async"
                         />
                     </div>
                     <div className="col-span-2 flex flex-col items-start md:items-end justify-end h-full text-left md:text-right">

--- a/src/components/projectSections/simpleCaptionImageSection.tsx
+++ b/src/components/projectSections/simpleCaptionImageSection.tsx
@@ -29,9 +29,11 @@ const SimpleImageSection = ({
                 {images.map((image, idx) => (
                     <div key={idx} className="w-full py-3">
                         <img
-                        src={image}
-                        alt={`${header} logo ${idx + 1}`}
-                        className="mx-auto"
+                            src={image}
+                            alt={`${header} logo ${idx + 1}`}
+                            className="mx-auto"
+                            loading="lazy"
+                            decoding="async"
                         />
                     </div>
                 ))}

--- a/src/pages/CaseStudies.tsx
+++ b/src/pages/CaseStudies.tsx
@@ -1,8 +1,4 @@
-import React, { useState, useEffect } from "react";
-import { useTypedText } from "../hooks/useTypedText";
-
 import ClickableImage from "../components/projectSections/ClickableImage";
-
 import aevia from "../assets/aevia.avif";
 import cavaMat from "../assets/cavaMat.avif";
 import babylon from "../assets/babylon.avif";
@@ -13,41 +9,22 @@ interface CaseStudiesProps {
   onNavigate: (path: string) => void;
 }
 
-function CaseStudies({ onNavigate }: CaseStudiesProps) {
-  const typed = useTypedText(["a product", "an app", "a web", "an industrial"], 150, 1000);
+const caseStudies = [
+  { header: "aevia", image: aevia },
+  { header: "cava-mat", image: cavaMat },
+  { header: "babylon", image: babylon },
+  { header: "oebab-cat", image: oebabCat },
+  { header: "linq", image: linq },
+];
 
+function CaseStudies({ onNavigate: _onNavigate }: CaseStudiesProps) {
   return (
     <div>
-      <section>
-        <ClickableImage
-          header="aevia"
-          image={aevia}
-        />
-      </section>
-      <section>
-        <ClickableImage
-          header="cava-mat"
-          image={cavaMat}
-        />
-      </section>
-      <section>
-        <ClickableImage
-          header="babylon"
-          image={babylon}
-        />
-      </section>
-      <section>
-        <ClickableImage
-          header="oebab-cat"
-          image={oebabCat}
-        />
-      </section>
-      <section>
-        <ClickableImage
-          header="linq"
-          image={linq}
-        />
-      </section>
+      {caseStudies.map((study) => (
+        <section key={study.header}>
+          <ClickableImage header={study.header} image={study.image} />
+        </section>
+      ))}
     </div>
   );
 }

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,9 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import { useTypedText } from "../hooks/useTypedText";
-
 import WorkShowcase from "../components/WorkShowcase";
-
 import stateFarm from "../assets/stateFarm.avif";
 import gap from "../assets/gap.avif";
 import geico from "../assets/geico.avif";
@@ -15,6 +11,68 @@ import casestudies from "../assets/casestudies.avif";
 interface PortfolioProps {
   onNavigate: (path: string) => void;
 }
+
+const featuredProjects = [
+  {
+    image: stateFarm,
+    category: "Mobile UI, Design Systems",
+    title: "State Farm",
+    description:
+      "Created mobile experiences for SFMA (State Farm Mobile App) claims, billing and payments, documents center, and built components for the mobile design system.",
+    path: "projects/state-farm",
+  },
+  {
+    image: geico,
+    category: "Design Systems, Web and Mobile UI/UX",
+    title: "GEICO",
+    description:
+      "Ensured the cohesiveness of the GEICO design system delivery process. Designed internal applications to support top priority insurance initiatives to stay competitive in the industry.",
+    path: "projects/geico",
+  },
+  {
+    image: gap,
+    category: "Design Systems, Internal-facing UI, User Research",
+    title: "Gap Inc",
+    description:
+      "Created and maintained the Gap Inc Design System, and designed internal franchise modules for Gap order management and fulfillment.",
+    path: "projects/gap",
+    sectionClassName: "bg-stone-100",
+  },
+  {
+    image: cokeHonestTea,
+    category: "UX Research",
+    title: "Coca-Cola, Honest Tea",
+    description:
+      "Conducted user experience (UX) research and strategizing for the Honest Tea division of Coca-Cola. I designed moderated usability studies and created testing prototypes.",
+    path: "projects/coke-honest-tea",
+    sectionClassName: "bg-stone-100",
+  },
+  {
+    image: obsidian,
+    category: "Mobile and Web UI, Design Systems",
+    title: "Obsidian Global",
+    description:
+      "Designed and built new user-facing pages by creating UI/UX wireframes, and utilizing HTML, CSS and Javascript on the front-end to customize web pages.",
+    path: "projects/obsidian",
+  },
+  {
+    image: myeyedr,
+    category: "UX Research",
+    title: "MyEyeDr",
+    description:
+      "As a UX researcher, I conducted thorough UX research proposals on customer experience. I hosted UX workshops, and conducted research presentations.",
+    path: "projects/myeyedr",
+    sectionClassName: "bg-stone-100",
+  },
+  {
+    image: casestudies,
+    category: "UI/UX Design",
+    title: "Case Studies",
+    description:
+      "Showcasing my passion for user experience design in independent projects has allowed me to further my learning in the field of UI/UX. This compilation of projects include contracting to small-businesses in my community, as well as personal case studies.",
+    path: "case-studies",
+  },
+];
 
 function Portfolio({ onNavigate }: PortfolioProps) {
   const typed = useTypedText(["a product", "an app", "a web", "an industrial"], 150, 1000);
@@ -31,69 +89,17 @@ function Portfolio({ onNavigate }: PortfolioProps) {
           </div>
         </div>
       </section>
-      <section>
-        <WorkShowcase
-          image={stateFarm}
-          category="Mobile UI, Design Systems"
-          title="State Farm"
-          description="Created mobile experiences for SFMA (State Farm Mobile App) claims, billing and payments, documents center, and built components for the mobile design system."
-          onButtonClick={() => onNavigate("projects/state-farm")}
-        />
-      </section>
-      <section>
-        <WorkShowcase
-          image={geico}
-          category="Design Systems, Web and Mobile UI/UX"
-          title="GEICO"
-          description="Ensured the cohesiveness of the GEICO design system delivery process. Designed internal applications to support top priority insurance initiatives to stay competitive in the industry."
-          onButtonClick={() => onNavigate("projects/geico")}
-        />
-      </section>
-      <section className="bg-stone-100">
-        <WorkShowcase
-          image={gap}
-          category="Design Systems, Internal-facing UI, User Research"
-          title="Gap Inc"
-          description="Created and maintained the Gap Inc Design System, and designed internal franchise modules for Gap order management and fulfillment."
-          onButtonClick={() => onNavigate("projects/gap")}
-        />
-      </section>
-      <section className="bg-stone-100">
-        <WorkShowcase
-          image={cokeHonestTea}
-          category="UX Research"
-          title="Coca-Cola, Honest Tea"
-          description="Conducted user experience (UX) research and strategizing for the Honest Tea division of Coca-Cola. I designed moderated usability studies and created testing prototypes."
-          onButtonClick={() => onNavigate("projects/coke-honest-tea")}
-        />
-      </section>
-      <section>
-        <WorkShowcase
-          image={obsidian}
-          category="Mobile and Web UI, Design Systems"
-          title="Obsidian Global"
-          description="Designed and built new user-facing pages by creating UI/UX wireframes, and utilizing HTML, CSS and Javascript on the front-end to customize web pages."
-          onButtonClick={() => onNavigate("projects/obsidian")}
-        />
-      </section>
-      <section className="bg-stone-100">
-        <WorkShowcase
-          image={myeyedr}
-          category="UX Research"
-          title="MyEyeDr"
-          description="As a UX researcher, I conducted thorough UX research proposals on customer experience. I hosted UX workshops, and conducted research presentations."
-          onButtonClick={() => onNavigate("projects/myeyedr")}
-        />
-      </section>
-      <section>
-        <WorkShowcase
-          image={casestudies}
-          category="UI/UX Design"
-          title="Case Studies"
-          description="Showcasing my passion for user experience design in independent projects has allowed me to further my learning in the field of UI/UX. This compilation of projects include contracting to small-businesses in my community, as well as personal case studies."
-          onButtonClick={() => onNavigate("case-studies")}
-        />
-      </section>
+      {featuredProjects.map((project) => (
+        <section key={project.title} className={project.sectionClassName}>
+          <WorkShowcase
+            image={project.image}
+            category={project.category}
+            title={project.title}
+            description={project.description}
+            onButtonClick={() => onNavigate(project.path)}
+          />
+        </section>
+      ))}
     </div>
   );
 }

--- a/src/pages/WorkDetail.tsx
+++ b/src/pages/WorkDetail.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { ComponentType, useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
-import projectData, { SectionData } from "../data/projectData";
+import projectData, { SectionData, SectionType } from "../data/projectData";
 import SimpleTitleSection from "../components/projectSections/SimpleTitleSection";
 import SimpleFullSection from "../components/projectSections/SimpleFullSection";
 import SimpleLeftTextSection from "../components/projectSections/SimpleLeftTextSection";
@@ -24,6 +24,29 @@ import ImageSlideSection from "../components/projectSections/ImageSlideSection";
 const GEICO_PROJECT_KEY = "geico";
 const GEICO_ACCESS_STORAGE_KEY = "geico_access_granted";
 const GEICO_PASSWORD_HASH = import.meta.env.VITE_GEICO_PASSWORD_HASH;
+const SLIDE_BATCH_SIZE = 4;
+
+const sectionComponents: Record<SectionType, ComponentType<any>> = {
+    simpleTitle: SimpleTitleSection,
+    simpleFullSection: SimpleFullSection,
+    simpleLeftTextSection: SimpleLeftTextSection,
+    simpleRightTextSection: SimpleRightTextSection,
+    multipleLogosTitleSection: MultipleLogosTitleSection,
+    complexFullSection: ComplexFullSection,
+    complexSingleLogoTitleSection: ComplexSingleLogoTitleSection,
+    simpleTextImageOverlaySection: SimpleTextImageOverlaySection,
+    multipleImageFullSection: MultipleImageFullSection,
+    complexLeftTextImageListSection: ComplexLeftTextImageListSection,
+    workShowcase: WorkShowcase,
+    simpleListSection: SimpleListSection,
+    complexDataFullSection: ComplexDataFullSection,
+    simpleLeftBulletImageSection: SimpleLeftBulletImageSection,
+    simpleImageSection: SimpleImageSection,
+    simpleCaptionImageSection: SimpleCaptionImageSection,
+    complexGridImageSection: ComplexGridImageSection,
+    imageSlideSection: ImageSlideSection,
+    conclusion: SimpleFullSection,
+};
 
 const toSha256 = async (value: string | undefined) => {
     const encoder = new TextEncoder();
@@ -38,14 +61,28 @@ const WorkDetail = () => {
     const { projectName, caseName } = useParams();
     const [isAccessGranted, setIsAccessGranted] = useState(false);
     const [isAccessCheckDone, setIsAccessCheckDone] = useState(false);
+    const [visibleSectionCount, setVisibleSectionCount] = useState(SLIDE_BATCH_SIZE);
     const project = projectData[projectName ?? ""];
+    const sections = useMemo(
+        () => (caseName ? project?.cases?.[caseName]?.sections : project?.sections) ?? null,
+        [caseName, project]
+    );
+    const isSlideDeckProject = useMemo(
+        () => Boolean(sections?.length) && sections!.every((section) => section.type === "imageSlideSection"),
+        [sections]
+    );
+    const visibleSections = useMemo(() => {
+        if (!sections) {
+            return null;
+        }
+
+        return isSlideDeckProject ? sections.slice(0, visibleSectionCount) : sections;
+    }, [isSlideDeckProject, sections, visibleSectionCount]);
 
     useEffect(() => {
         let isCancelled = false;
 
         const checkAccess = async () => {
-            console.log("Checking access for project:", projectName);
-
             if (projectName !== GEICO_PROJECT_KEY) {
                 setIsAccessGranted(true);
                 setIsAccessCheckDone(true);
@@ -53,7 +90,6 @@ const WorkDetail = () => {
             }
 
             const hasSessionAccess = sessionStorage.getItem(GEICO_ACCESS_STORAGE_KEY) === "true";
-            console.log("Session access:", hasSessionAccess);
 
             if (hasSessionAccess) {
                 setIsAccessGranted(true);
@@ -62,7 +98,6 @@ const WorkDetail = () => {
             }
 
             const enteredPassword = window.prompt("Enter password to access this project:");
-            console.log("Entered password:", enteredPassword);
 
             if (!enteredPassword) {
                 setIsAccessGranted(false);
@@ -78,10 +113,7 @@ const WorkDetail = () => {
             }
 
             const enteredHash = await toSha256(enteredPassword);
-            console.log("Entered hash:", enteredHash);
-
             const isValid = enteredHash === GEICO_PASSWORD_HASH;
-            console.log("Is valid:", isValid);
 
             if (!isCancelled) {
                 if (isValid) {
@@ -95,52 +127,45 @@ const WorkDetail = () => {
             }
         };
 
-        const timeoutId = window.setTimeout(() => {
-            void checkAccess();
-        }, 0);
+        void checkAccess();
         
         return () => {
             isCancelled = true;
-            window.clearTimeout(timeoutId);
         };
     }, [projectName]);
 
-    const sections = caseName ? project?.cases?.[caseName]?.sections : null;
+    useEffect(() => {
+        setVisibleSectionCount(SLIDE_BATCH_SIZE);
+    }, [projectName, caseName]);
 
     if (!isAccessCheckDone) return null;
     if (!isAccessGranted) return <NotFound />;
+    if (!project || !visibleSections) return <NotFound />;
 
-    const returnSections = (sectionsList: any[]) => (
-        <>
-            {sectionsList.map((section, idx) => {
-                switch(section.type) {
-                    case "simpleTitle": return <SimpleTitleSection key={idx} {...section.data} />;
-                    case "simpleFullSection": return <SimpleFullSection key={idx} {...section.data} />;
-                    case "simpleLeftTextSection": return <SimpleLeftTextSection key={idx} {...section.data} />;
-                    case "simpleRightTextSection": return <SimpleRightTextSection key={idx} {...section.data} />;
-                    case "multipleLogosTitleSection": return <MultipleLogosTitleSection key={idx} {...section.data} />;
-                    case "complexFullSection": return <ComplexFullSection key={idx} {...section.data} />;
-                    case "complexSingleLogoTitleSection": return <ComplexSingleLogoTitleSection key={idx} {...section.data} />;
-                    case "simpleTextImageOverlaySection": return <SimpleTextImageOverlaySection key={idx} {...section.data} />;
-                    case "multipleImageFullSection": return <MultipleImageFullSection key={idx} {...section.data} />;
-                    case "complexLeftTextImageListSection": return <ComplexLeftTextImageListSection key={idx} {...section.data} />;
-                    case "workShowcase": return <WorkShowcase key={idx} {...section.data} />;
-                    case "simpleListSection": return <SimpleListSection key={idx} {...section.data} />;
-                    case "complexDataFullSection": return <ComplexDataFullSection key={idx} {...section.data} />;
-                    case "simpleLeftBulletImageSection": return <SimpleLeftBulletImageSection key={idx} {...section.data} />;
-                    case "simpleImageSection": return <SimpleImageSection key={idx} {...section.data} />;
-                    case "simpleCaptionImageSection": return <SimpleCaptionImageSection key={idx} {...section.data} />;
-                    case "complexGridImageSection": return <ComplexGridImageSection key={idx} {...section.data} />;
-                    case "imageSlideSection": return <ImageSlideSection key={idx} {...section.data} />;
-                    default: return null;
+    return (
+        <div>
+            {visibleSections.map((section: SectionData, idx) => {
+                const SectionComponent = sectionComponents[section.type];
+
+                if (!SectionComponent) {
+                    return null;
                 }
-            })}
-        </>
-    );
 
-    if (project && !sections) return returnSections(project.sections);
-    if (project && sections) return returnSections(sections);
-    return <NotFound />;
+                return <SectionComponent key={`${section.type}-${idx}`} {...section.data} />;
+            })}
+            {isSlideDeckProject && sections && visibleSectionCount < sections.length ? (
+                <div className="mx-auto flex max-w-5xl justify-center px-6 py-8">
+                    <button
+                        type="button"
+                        onClick={() => setVisibleSectionCount((current) => current + SLIDE_BATCH_SIZE)}
+                        className="rounded-3xl bg-stone-800 px-8 py-3 text-white transition-colors hover:bg-stone-700"
+                    >
+                        Load more slides
+                    </button>
+                </div>
+            ) : null}
+        </div>
+    );
 };
 
 export default WorkDetail;


### PR DESCRIPTION
I refactored the app to lazy-load non-home routes in [src/App.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/), so About, Resume, CaseStudies, and WorkDetail now split into separate chunks instead of inflating the entry bundle. That dropped the main JS chunk from about 422.8 kB to 350.3 kB in the production build, and moved WorkDetail into its own 61.6 kB chunk.

I also cleaned up the detail page in [src/pages/WorkDetail.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/) by replacing the long switch with a component registry, removing debug logging, and simplifying how sections are resolved. On top of that, I de-duplicated repeated page config in [src/pages/Portfolio.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/) and [src/pages/CaseStudies.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/), and added loading="lazy" / decoding="async" to repeated image renderers such as [src/components/WorkShowcase.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/), [src/components/projectSections/ImageSlideSection.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/), and [src/components/projectSections/ComplexGridImageSection.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/).

I added a second optimization pass focused on delivery, since true recompression isn’t possible in this environment without an image encoder.

In [src/pages/WorkDetail.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/), slide-deck projects now render in batches of 4 with a Load more slides control instead of mounting every large slide immediately. That reduces initial DOM work and prevents the browser from queueing a long run of heavy images on first load.

I also added lazy/async loading to the remaining large image sections in [src/components/projectSections/SimpleImageSection.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/), [src/components/projectSections/simpleCaptionImageSection.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/), [src/components/projectSections/MultipleImageFullSection.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/), [src/components/projectSections/SimpleLeftTextSection.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/), and [src/components/projectSections/SimpleRightTextSection.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/aluoc/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/).